### PR TITLE
WorkingGroup.rho - based on sealer / unsealer pattern

### DIFF
--- a/WorkingGroup.rho
+++ b/WorkingGroup.rho
@@ -1,0 +1,93 @@
+new trace, rl(`rho:registry:lookup`),
+WorkingGroup,
+ch, ex, dcCh, gcCh, jwCh, toJim, toDan in {
+  rl!(`rho:id:b9s6j3xeobgset4ndn64hje64grfcj7a43eekb3fh43yso5ujiecfn`, *ch)
+  |
+  for (@(_, *MultiSigRevVault) <- ch) {
+    trace!("got MultiSigRevVault") |
+    MultiSigRevVault!("makeSealerUnsealer", *dcCh) |
+    for (@(*dcSealer, *dcUnsealer) <- dcCh) {
+      trace!("got dc brand") |
+      toJim!(*dcUnsealer) |
+      for(wg <- toDan) {
+        wg!("agree", *ex, "DC", "un-signed/sealed proposal", *ch) |
+        for (@problem <- ex) {
+          trace!(problem)
+        }
+        |
+        new sealCh, pEx, pOk in {
+          dcSealer!(trace!("spend 100 REV on stuff."), *sealCh) | for (@sealedProposal <- sealCh) {
+            wg!("agree", *pEx, "DC", sealedProposal, *pOk) |
+            for (@result <- pOk) {
+              trace!(result)
+            }
+          }
+        }
+      }
+    }
+    |
+    MultiSigRevVault!("makeSealerUnsealer", *jwCh) |
+    for (@(*jwSealer, *jwUnsealer) <- jwCh; dcUnsealer <- toJim) {
+      trace!("got jw brand") |
+      WorkingGroup!({"DC": *dcUnsealer, "JW": *jwUnsealer}, 2, *ch) | for (wg <- ch) {
+        toDan!(*wg) |
+        new sealCh, pEx, pOk in {
+          jwSealer!(trace!("spend 100 REV on stuff."), *sealCh) | for (@sealedProposal <- sealCh) {
+            wg!("agree", *pEx, "JW", sealedProposal, *pOk) |
+            for (@result <- pOk) {
+              trace!(result)
+            }
+          }
+        }
+      }
+    }
+    |
+    contract WorkingGroup(@unsealers, @quorum, ret) = {
+      trace!(["WorkingGroup", unsealers.size(), quorum]) |
+      new pendingCh, self, unsCh in {
+        pendingCh!({}) |
+        ret!(*self) |
+        contract self(@"agree", ej, @by, @sealedProposal, ret) = {
+          trace!(["agree", by]) |
+          match unsealers.get(by) {
+            Nil => ej!({"message": "by ${by} not known" %% {"by": by}})
+            whoseUnsealer => {
+              trace!(["found unsealer...", by]) |
+              @whoseUnsealer!(sealedProposal, *unsCh) |
+              for (@(ok, what) <- unsCh) {
+                match ok {
+                  false => ej!({"message": what})
+                  true => {
+                    for(@pending <- pendingCh) {
+                      match (pending.get(what)) {
+                        Nil => {
+                          trace!(["new proposal by", by]) |
+                          pendingCh!(pending.set(what, Set(by))) |
+                          ret!(quorum - 1)
+                        }
+                        supporters => {
+                          trace!(["adding", by, supporters.size()]) |
+                          match (supporters.size() + 1 >= quorum) {
+                            false => {
+                              pendingCh!(pending.set(what, supporters.union(Set(by)))) |
+                              ret!(quorum - (supporters.size() + 1))
+                            }
+                            true => {
+                              pendingCh!(pending.delete(what)) |
+                              what |
+                              ret!(0)
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/WorkingGroup.rho
+++ b/WorkingGroup.rho
@@ -1,6 +1,6 @@
 new trace, rl(`rho:registry:lookup`),
 insertArbitrary(`rho:registry:insertArbitrary`),
-WorkingGroup, TestFundWG,
+WorkingGroup, TestFundWG, closeWG,
 rCh, toJim, toDan, testsPass in {
   /**
    * Test Scenario: Dan and Jim are starting a working group
@@ -40,7 +40,17 @@ rCh, toJim, toDan, testsPass in {
           dcSealer!(("pay", "Bob", 100), *sealCh) | for (@sealedProposal <- sealCh) {
             wg!("agree", *pEx, "DC", sealedProposal, *pOk) |
             // Either Dan or Jim may be the deciding vote.
-            for (@(true, result) <- pOk) { testsPass!(result) }
+            for (@voteResult <- pOk) {
+              trace!(["DC vote result", voteResult]) |
+              // vote to close the WG
+              dcSealer!(*closeWG, *sealCh) | for (@sealedProposal <- sealCh) {
+                wg!("modifyMembership", *pEx, "DC", sealedProposal, *pOk) |
+                // Either Dan or Jim may be the deciding vote.
+                for (@(true, result) <- pOk) {
+                  testsPass!(result)
+                }
+              }
+            }
           }
         }
       }
@@ -59,14 +69,26 @@ rCh, toJim, toDan, testsPass in {
           jwSealer!(("pay", "Bob", 100), *sealCh) | for (@sealedProposal <- sealCh) {
             wg!("agree", *pEx, "JW", sealedProposal, *pOk) |
             // Either Dan or Jim may be the deciding vote.
-            for (@(true, result) <- pOk) { testsPass!(result) }
+            for (@voteResult <- pOk) {
+              trace!(["JW vote result", voteResult]) |
+              // vote to close the WG
+              jwSealer!(*closeWG, *sealCh) | for (@sealedProposal <- sealCh) {
+                wg!("modifyMembership", *pEx, "JW", sealedProposal, *pOk) |
+                // Either Dan or Jim may be the deciding vote.
+                for (@(true, result) <- pOk) {
+                  testsPass!(result)
+                }
+              }
+            }
           }
         }
       }
     }
     |
+    contract closeWG(_oldMem, ret) = { ret!({}) }
+    |
     contract testsPass(@result) = {
-      trace!(["fund.pay result", result]) |
+      trace!(["membership size", result]) |
       new uriCh in {
         insertArbitrary!(*WorkingGroup, *uriCh) | for (@uri <- uriCh) {
           trace!(["WorkingGroup registered at", uri])
@@ -74,53 +96,82 @@ rCh, toJim, toDan, testsPass in {
       }
     }
     |
-    contract WorkingGroup(@unsealers, @quorum, sharedPower, ret) = {
+    contract WorkingGroup(
+      @initialMembership /\ Map,  // member name to unsealer
+      @quorum /\ Int,
+      sharedPower,
+      ret
+    ) = {
       // trace!(["WorkingGroup", unsealers.size(), quorum]) |
-      new pendingCh, self, unsCh in {
+      new self, pendingCh, memCh in {
         pendingCh!({}) |
+        memCh!(initialMembership) |
         ret!(*self) |
-        contract self(@"agree", ej, @by, @sealedProposal, ret) = {
-          // trace!(["agree", by]) |
-          match unsealers.get(by) {
-            Nil => ej!({"message": "by ${by} not known" %% {"by": by}})
-            whoseUnsealer => {
-              // trace!(["found unsealer...", by]) |
-              @whoseUnsealer!(sealedProposal, *unsCh) |
-              for (@(ok, what) <- unsCh) {
-                match ok {
-                  false => ej!({"message": what})
-                  true => {
-                    for(@pending <- pendingCh) {
-                      match (pending.get(what)) {
-                        Nil => {
-                          // trace!(["new proposal by", by]) |
-                          pendingCh!(pending.set(what, Set(by))) |
-                          ret!((false, quorum - 1))
-                        }
-                        supporters => {
-                          // trace!(["adding", by, supporters.size()]) |
-                          match (supporters.size() + 1 >= quorum) {
-                            false => {
-                              pendingCh!(pending.set(what, supporters.union(Set(by)))) |
-                              ret!((false, quorum - (supporters.size() + 1)))
+        contract self(@"getMembership", ret) = {
+          for (@mem <<- memCh) { ret!(mem) }
+        } |
+        contract self(
+          @method /\ String, // agree or modifyMembership
+          ej, // ejector - channel for exceptional outcome (ISSUE: failed experiment?)
+          @by /\ String,
+          @sealedProposal,
+          ret
+        ) = {
+          new unsCh, rCh in {
+            // trace!([method, by]) |
+            for (@unsealers <<- memCh) {
+              match unsealers.get(by) {
+                Nil => ej!({"message": "by ${by} not known" %% {"by": by}})
+                whoseUnsealer => {
+                  // trace!(["found unsealer...", by]) |
+                  @whoseUnsealer!(sealedProposal, *unsCh) |
+                  for (@(ok, what) <- unsCh) {
+                    match ok {
+                      false => ej!({"message": what})
+                      true => {
+                        for(@pending <- pendingCh) {
+                          match (pending.get(what)) {
+                            Nil => {
+                              // trace!(["new proposal by", by]) |
+                              pendingCh!(pending.set(what, Set(by))) |
+                              ret!((false, quorum - 1))
                             }
-                            true => {
-                              // trace!(["proposal carries", what]) |
-                              pendingCh!(pending.delete(what)) |
-                              new rCh in {
-                                match what {
-                                  // We want to send an arbitrary number of processes
-                                  // (...args) => sharedPower!(...args)
-                                  // but I don't see how, so...
-                                  (m, a1) => sharedPower!(m, a1, *rCh)
-                                  (m, a1, a2) => sharedPower!(m, a1, a2, *rCh)
-                                  (m, a1, a2, a3) => sharedPower!(m, a1, a2, a3, *rCh)
-                                  (m, a1, a2, a3, a4) => sharedPower!(m, a1, a2, a3, a4, *rCh)
-                                  (m, a1, a2, a3, a4, a5) => sharedPower!(m, a1, a2, a3, a4, a5, *rCh)
-                                  x => sharedPower!(x, *rCh)
-                                } |
-                                for (@result <- rCh) {
-                                  ret!((true, result))
+                            supporters => {
+                              // trace!(["adding", by, supporters.size()]) |
+                              match (supporters.size() + 1 >= quorum) {
+                                false => {
+                                  pendingCh!(pending.set(what, supporters.union(Set(by)))) |
+                                  ret!((false, quorum - (supporters.size() + 1)))
+                                }
+                                true => {
+                                  // trace!(["proposal carries", what]) |
+                                  pendingCh!(pending.delete(what)) |
+                                  match (method, what) {
+                                    ("modifyMembership", *f) => {
+                                      new ch in {
+                                        for (@oldMem <- memCh) {
+                                          f!(oldMem, *ch) |
+                                          for (@newMem /\ Map <- ch) {
+                                            memCh!(newMem) |
+                                            rCh!(newMem.size())
+                                          }
+                                        }
+                                      }
+                                    }
+                                    // We want to send an arbitrary number of processes
+                                    // (...args) => sharedPower!(...args)
+                                    // but I don't see how, so...
+                                    ("agree", (m, a1)) => sharedPower!(m, a1, *rCh)
+                                    ("agree", (m, a1, a2)) => sharedPower!(m, a1, a2, *rCh)
+                                    ("agree", (m, a1, a2, a3)) => sharedPower!(m, a1, a2, a3, *rCh)
+                                    ("agree", (m, a1, a2, a3, a4)) => sharedPower!(m, a1, a2, a3, a4, *rCh)
+                                    ("agree", (m, a1, a2, a3, a4, a5)) => sharedPower!(m, a1, a2, a3, a4, a5, *rCh)
+                                    ("agree", x) => sharedPower!(x, *rCh)
+                                    x => ej!({"message": "bad method?"})
+                                  } |
+                                  for (@result <- rCh) {
+                                    ret!((true, result))
+                                  }
                                 }
                               }
                             }

--- a/WorkingGroup.rho
+++ b/WorkingGroup.rho
@@ -1,58 +1,90 @@
 new trace, rl(`rho:registry:lookup`),
-WorkingGroup,
-ch, ex, dcCh, gcCh, jwCh, toJim, toDan in {
-  rl!(`rho:id:b9s6j3xeobgset4ndn64hje64grfcj7a43eekb3fh43yso5ujiecfn`, *ch)
+insertArbitrary(`rho:registry:insertArbitrary`),
+WorkingGroup, TestFundWG,
+rCh, toJim, toDan, testsPass in {
+  /**
+   * Test Scenario: Dan and Jim are starting a working group
+   * to control, for example, a fund. Note that neither Dan
+   * nor Jim has the fund in scope; they can only invoke it
+   * (to pay someone) by mutual action.
+   */
+  contract TestFundWG(@unsealers /\ Map, @quorum /\ Int, ret) = {
+    new fund in {
+      WorkingGroup!(unsealers, quorum, *fund, *ret) |
+      contract fund(@"pay", whom, @amt, ret) = {
+        // manipulate amt just to show we did some computation here
+        ret!(amt - 1)
+      }
+    }
+  }
   |
-  for (@(_, *MultiSigRevVault) <- ch) {
+  // Sealer / Unsealer pairs (aka brands) are available from the MultiSigRevVault contract.
+  rl!(`rho:id:b9s6j3xeobgset4ndn64hje64grfcj7a43eekb3fh43yso5ujiecfn`, *rCh) |
+  for (@(_, *MultiSigRevVault) <- rCh) {
     trace!("got MultiSigRevVault") |
-    MultiSigRevVault!("makeSealerUnsealer", *dcCh) |
-    for (@(*dcSealer, *dcUnsealer) <- dcCh) {
-      trace!("got dc brand") |
-      toJim!(*dcUnsealer) |
-      for(wg <- toDan) {
-        wg!("agree", *ex, "DC", "un-signed/sealed proposal", *ch) |
-        for (@problem <- ex) {
-          trace!(problem)
-        }
-        |
-        new sealCh, pEx, pOk in {
-          dcSealer!(trace!("spend 100 REV on stuff."), *sealCh) | for (@sealedProposal <- sealCh) {
+
+    // Dan makes a brand, sends the unsealer on toJim,
+    // and uses the sealer on his agreement to pay Bob 100
+    // once he gets the wg from Jim on toDan.
+    new ch, ex, dcCh, sealCh, pEx, pOk in {
+      MultiSigRevVault!("makeSealerUnsealer", *dcCh) |
+      for (@(*dcSealer, *dcUnsealer) <- dcCh) {
+        trace!("got dc brand") |
+        toJim!(*dcUnsealer) |
+        for(wg <- toDan) {
+          wg!("agree", *ex, "DC", "un-signed/sealed proposal", *ch) |
+          for (@problem <- ex) {
+            trace!(problem)
+          }
+          |
+          dcSealer!(("pay", "Bob", 100), *sealCh) | for (@sealedProposal <- sealCh) {
             wg!("agree", *pEx, "DC", sealedProposal, *pOk) |
-            for (@result <- pOk) {
-              trace!(result)
-            }
+            // Either Dan or Jim may be the deciding vote.
+            for (@(true, result) <- pOk) { testsPass!(result) }
           }
         }
       }
     }
     |
-    MultiSigRevVault!("makeSealerUnsealer", *jwCh) |
-    for (@(*jwSealer, *jwUnsealer) <- jwCh; dcUnsealer <- toJim) {
-      trace!("got jw brand") |
-      WorkingGroup!({"DC": *dcUnsealer, "JW": *jwUnsealer}, 2, *ch) | for (wg <- ch) {
-        toDan!(*wg) |
-        new sealCh, pEx, pOk in {
-          jwSealer!(trace!("spend 100 REV on stuff."), *sealCh) | for (@sealedProposal <- sealCh) {
+
+    // Jim makes a brand and uses his and Dan's unsealers
+    // to make a FundWG, which he sends on toDan.
+    // Jim uses his sealer on his agreement to pay Bob 100.
+    new ch, ex, jwCh, sealCh, pEx, pOk in {
+      MultiSigRevVault!("makeSealerUnsealer", *jwCh) |
+      for (@(*jwSealer, *jwUnsealer) <- jwCh; dcUnsealer <- toJim) {
+        trace!("got jw brand") |
+        TestFundWG!({"DC": *dcUnsealer, "JW": *jwUnsealer}, 2, *ch) | for (wg <- ch) {
+          toDan!(*wg) |
+          jwSealer!(("pay", "Bob", 100), *sealCh) | for (@sealedProposal <- sealCh) {
             wg!("agree", *pEx, "JW", sealedProposal, *pOk) |
-            for (@result <- pOk) {
-              trace!(result)
-            }
+            // Either Dan or Jim may be the deciding vote.
+            for (@(true, result) <- pOk) { testsPass!(result) }
           }
         }
       }
     }
     |
-    contract WorkingGroup(@unsealers, @quorum, ret) = {
-      trace!(["WorkingGroup", unsealers.size(), quorum]) |
+    contract testsPass(@result) = {
+      trace!(["fund.pay result", result]) |
+      new uriCh in {
+        insertArbitrary!(*WorkingGroup, *uriCh) | for (@uri <- uriCh) {
+          trace!(["WorkingGroup registered at", uri])
+        }
+      }
+    }
+    |
+    contract WorkingGroup(@unsealers, @quorum, sharedPower, ret) = {
+      // trace!(["WorkingGroup", unsealers.size(), quorum]) |
       new pendingCh, self, unsCh in {
         pendingCh!({}) |
         ret!(*self) |
         contract self(@"agree", ej, @by, @sealedProposal, ret) = {
-          trace!(["agree", by]) |
+          // trace!(["agree", by]) |
           match unsealers.get(by) {
             Nil => ej!({"message": "by ${by} not known" %% {"by": by}})
             whoseUnsealer => {
-              trace!(["found unsealer...", by]) |
+              // trace!(["found unsealer...", by]) |
               @whoseUnsealer!(sealedProposal, *unsCh) |
               for (@(ok, what) <- unsCh) {
                 match ok {
@@ -61,21 +93,36 @@ ch, ex, dcCh, gcCh, jwCh, toJim, toDan in {
                     for(@pending <- pendingCh) {
                       match (pending.get(what)) {
                         Nil => {
-                          trace!(["new proposal by", by]) |
+                          // trace!(["new proposal by", by]) |
                           pendingCh!(pending.set(what, Set(by))) |
-                          ret!(quorum - 1)
+                          ret!((false, quorum - 1))
                         }
                         supporters => {
-                          trace!(["adding", by, supporters.size()]) |
+                          // trace!(["adding", by, supporters.size()]) |
                           match (supporters.size() + 1 >= quorum) {
                             false => {
                               pendingCh!(pending.set(what, supporters.union(Set(by)))) |
-                              ret!(quorum - (supporters.size() + 1))
+                              ret!((false, quorum - (supporters.size() + 1)))
                             }
                             true => {
+                              // trace!(["proposal carries", what]) |
                               pendingCh!(pending.delete(what)) |
-                              what |
-                              ret!(0)
+                              new rCh in {
+                                match what {
+                                  // We want to send an arbitrary number of processes
+                                  // (...args) => sharedPower!(...args)
+                                  // but I don't see how, so...
+                                  (m, a1) => sharedPower!(m, a1, *rCh)
+                                  (m, a1, a2) => sharedPower!(m, a1, a2, *rCh)
+                                  (m, a1, a2, a3) => sharedPower!(m, a1, a2, a3, *rCh)
+                                  (m, a1, a2, a3, a4) => sharedPower!(m, a1, a2, a3, a4, *rCh)
+                                  (m, a1, a2, a3, a4, a5) => sharedPower!(m, a1, a2, a3, a4, a5, *rCh)
+                                  x => sharedPower!(x, *rCh)
+                                } |
+                                for (@result <- rCh) {
+                                  ret!((true, result))
+                                }
+                              }
                             }
                           }
                         }

--- a/src/participate.html
+++ b/src/participate.html
@@ -19,14 +19,6 @@
   <div>
     <h1>Liquid Democracy Participation Experiment</h1>
 
-    <p>idea: show avatars for members; give emoji kudos <a href="https://emojipedia.org/red-heart/">❤️</a></p>
-    <h3>ToDo</h3>
-    <ul>
-      <li>handle multiple deploys concurrently</li>
-      <li>"insert 25cents to play" account rather than in-your-face signature at each move</li>
-      <li>push more of the actions down into deployed contracts</li>
-      <li>provide access to #define bindings in actions</li>
-    </ul>
     <form>
       <fieldset>
         <div id="actionControl" class="mount">
@@ -64,6 +56,14 @@
         </div>
       </fieldset>
     </form>
+    <p>idea: show avatars for members; give emoji kudos <a href="https://emojipedia.org/red-heart/">❤️</a></p>
+    <h3>ToDo</h3>
+    <ul>
+      <li>handle multiple deploys concurrently</li>
+      <li>"insert 25cents to play" account rather than in-your-face signature at each move</li>
+      <li>push more of the actions down into deployed contracts</li>
+      <li>provide access to #define bindings in actions</li>
+    </ul>
     <div id="groupControl">
       <h3>Members...</h3>
     </div>


### PR DESCRIPTION
The **WorkingGroup** contract lets multiple parties coordinate messages sent to a shared power.

## Test Scenario / trace output

_Dan and Jim are starting a working group to control, for example, a fund._

_[Sealer / Unsealer pairs (aka brands)][1] are available from the `MultiSigRevVault` contract. Dan makes a brand, sends the unsealer on `toJim`, and, once he gets the wg from Jim on `toDan`, uses the sealer on his agreement to pay Bob 100. Either Jim or Dan could be the deciding vote._

_Jim makes a brand and uses his and Dan's unsealers to make a FundWG, which he sends on toDan. Jim uses his sealer on his agreement to pay Bob 100._

In this case, DC's vote left 1 supporter pending and JW's was the deciding vote; 99 represents the shared power doing some computation (subtracting 1) on the proposal:

```
      "got MultiSigRevVault",
      "got dc brand",
      "got jw brand",

      [ "DC vote result", [ false, 1 ] ],
      [ "JW vote result", [ true, 99 ] ],

```

_Proposals not signed / sealed by a WG member are rejected._

```
      { "message": "Invalid box" },
```

_Jim and Dan then use **modifyMembership** to close the WG._

```
      ["membership size", 0],
```

It's deployed to testnet at `rho:id:znbjypn9rsxz96gj4j5g1qsrzbma46wguff6x57gbaky5ntn7gz6px`.

[1]: https://github.com/dckc/awesome-ocap/wiki/SealerUnsealer